### PR TITLE
Enable OnePlus Camera support

### DIFF
--- a/common.mk
+++ b/common.mk
@@ -364,6 +364,10 @@ PRODUCT_PACKAGES += \
 PRODUCT_COPY_FILES += \
     $(LOCAL_PATH)/configs/privapp-permissions-qti.xml:system/etc/permissions/privapp-permissions-qti.xml
 
+# OPCam priv-app Whitelist
+PRODUCT_COPY_FILES += \
+    $(LOCAL_PATH)/configs/privapp-permissions-opcam.xml:system/etc/permissions/privapp-permissions-opcam.xml
+
 # Power
 PRODUCT_PACKAGES += \
     android.hardware.power@1.2-service.msm8998-libperfmgr

--- a/configs/privapp-permissions-opcam.xml
+++ b/configs/privapp-permissions-opcam.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="utf-8"?>
+<permissions>
+    <privapp-permissions package="com.oneplus.camera">
+        <permission name="android.permission.WRITE_SETTINGS"/>
+        <permission name="android.permission.CHANGE_CONFIGURATION"/>
+        <permission name="android.permission.INTERACT_ACROSS_USERS"/>
+        <permission name="android.permission.MOUNT_UNMOUNT_FILESYSTEMS"/>
+        <permission name="android.permission.READ_LOGS"/>
+        <permission name="android.permission.WRITE_MEDIA_STORAGE"/>
+    </privapp-permissions>
+
+    <privapp-permissions package="com.oneplus.gallery">
+        <permission name="android.permission.WRITE_SETTINGS"/>
+        <permission name="android.permission.WRITE_MEDIA_STORAGE"/>
+    </privapp-permissions>
+</permissions>

--- a/overlay/frameworks/base/core/res/res/values/config.xml
+++ b/overlay/frameworks/base/core/res/res/values/config.xml
@@ -698,4 +698,7 @@
    <!-- Defines the sysfs attribute path used by pocket bridge
    to communicate pocket state to the pocket judge kernel driver. -->
    <string name="config_pocketBridgeSysfsInpocket">/sys/kernel/pocket_judge/inpocket</string>
+
+   <!-- Whether to enable oneplus cam hack -->
+   <bool name="config_enableOPcamhack">true</bool>
 </resources>


### PR DESCRIPTION
AICP has necessary changes in ROM source (AICP/frameworks_base@6403f48 and frameworks/native), but not enabled in DT, why?